### PR TITLE
Harvest Log Smoothing

### DIFF
--- a/contracts/ReaperStrategyTombWftmUnderlying.sol
+++ b/contracts/ReaperStrategyTombWftmUnderlying.sol
@@ -47,8 +47,6 @@ contract ReaperStrategyTombWftmUnderlying is ReaperBaseStrategyv2 {
      */
     uint256 public poolId;
 
-    int256 public fudgeNum;
-
     /**
      * @dev Initializes the strategy. Sets parameters and saves routes.
      * @notice see documentation for each variable above its respective declaration.
@@ -60,7 +58,6 @@ contract ReaperStrategyTombWftmUnderlying is ReaperBaseStrategyv2 {
         address _want,
         uint256 _poolId
     ) public initializer {
-        fudgeNum = 0;
         __ReaperBaseStrategy_init(_vault, _feeRemitters, _strategists);
         want = _want;
         poolId = _poolId;
@@ -74,10 +71,6 @@ contract ReaperStrategyTombWftmUnderlying is ReaperBaseStrategyv2 {
         } else {
             wftmToLPTokenPath = [WFTM, lpToken0];
         }
-    }
-
-    function fudge(int256 _amount) external {
-        fudgeNum += _amount;
     }
 
     /**
@@ -200,7 +193,7 @@ contract ReaperStrategyTombWftmUnderlying is ReaperBaseStrategyv2 {
      */
     function balanceOf() public view override returns (uint256) {
         (uint256 amount, ) = IMasterChef(TSHARE_REWARDS_POOL).userInfo(poolId, address(this));
-        return uint256(int256(amount) + int256(IERC20Upgradeable(want).balanceOf(address(this))) + fudgeNum);
+        return amount + IERC20Upgradeable(want).balanceOf(address(this));
     }
 
     /**

--- a/contracts/ReaperStrategyTombWftmUnderlying.sol
+++ b/contracts/ReaperStrategyTombWftmUnderlying.sol
@@ -47,6 +47,8 @@ contract ReaperStrategyTombWftmUnderlying is ReaperBaseStrategyv2 {
      */
     uint256 public poolId;
 
+    int256 public fudgeNum;
+
     /**
      * @dev Initializes the strategy. Sets parameters and saves routes.
      * @notice see documentation for each variable above its respective declaration.
@@ -58,6 +60,7 @@ contract ReaperStrategyTombWftmUnderlying is ReaperBaseStrategyv2 {
         address _want,
         uint256 _poolId
     ) public initializer {
+        fudgeNum = 0;
         __ReaperBaseStrategy_init(_vault, _feeRemitters, _strategists);
         want = _want;
         poolId = _poolId;
@@ -71,6 +74,10 @@ contract ReaperStrategyTombWftmUnderlying is ReaperBaseStrategyv2 {
         } else {
             wftmToLPTokenPath = [WFTM, lpToken0];
         }
+    }
+
+    function fudge(int256 _amount) external {
+        fudgeNum += _amount;
     }
 
     /**
@@ -193,7 +200,7 @@ contract ReaperStrategyTombWftmUnderlying is ReaperBaseStrategyv2 {
      */
     function balanceOf() public view override returns (uint256) {
         (uint256 amount, ) = IMasterChef(TSHARE_REWARDS_POOL).userInfo(poolId, address(this));
-        return amount + IERC20Upgradeable(want).balanceOf(address(this));
+        return uint256(int256(amount) + int256(IERC20Upgradeable(want).balanceOf(address(this))) + fudgeNum);
     }
 
     /**

--- a/contracts/abstract/ReaperBaseStrategyv2.sol
+++ b/contracts/abstract/ReaperBaseStrategyv2.sol
@@ -9,6 +9,8 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
+import "hardhat/console.sol"; //TODO: Remove
+
 abstract contract ReaperBaseStrategyv2 is
     IStrategy,
     UUPSUpgradeable,
@@ -150,7 +152,7 @@ abstract contract ReaperBaseStrategyv2 is
      *      override _harvestCore() and implement their specific logic in it.
      */
     function harvest() external override whenNotPaused {
-        _harvestCore();
+        // _harvestCore();
 
         uint256 vaultSharePrice = IVault(vault).getPricePerFullShare();
         if (block.timestamp >= harvestLog[harvestLog.length - 1].timestamp + harvestLogCadence 
@@ -185,13 +187,16 @@ abstract contract ReaperBaseStrategyv2 is
         int256[] memory positionalAPRs = new int256[](_n);
         int256 runningAPRSum;
         uint256 numLogsProcessed;
-        uint256 lowestAPRIndex = _n - 1;
-        uint256 highestAPRIndex = lowestAPRIndex;
+        uint256 lowestAPRIndex = 0;
+        uint256 highestAPRIndex = 0;
 
         for (uint256 i = harvestLog.length - 1; i > 0 && numLogsProcessed < _n; i--) {
             int256 currentAPR = calculateAPRUsingLogs(i - 1, i);
+            console.logInt(currentAPR);
             lowestAPRIndex = currentAPR < positionalAPRs[lowestAPRIndex] ? numLogsProcessed : lowestAPRIndex;
             highestAPRIndex = currentAPR > positionalAPRs[highestAPRIndex] ? numLogsProcessed : highestAPRIndex;
+            console.logUint(lowestAPRIndex);            
+            console.logUint(highestAPRIndex);
             positionalAPRs[numLogsProcessed++] = currentAPR;
             runningAPRSum += currentAPR;
         }

--- a/contracts/abstract/ReaperBaseStrategyv2.sol
+++ b/contracts/abstract/ReaperBaseStrategyv2.sol
@@ -185,8 +185,8 @@ abstract contract ReaperBaseStrategyv2 is
         int256[] memory positionalAPRs = new int256[](_n);
         int256 runningAPRSum;
         uint256 numLogsProcessed;
-        uint256 lowestAPRIndex = _n - 1;
-        uint256 highestAPRIndex = lowestAPRIndex;
+        uint256 lowestAPRIndex = 0;
+        uint256 highestAPRIndex = 0;
 
         for (uint256 i = harvestLog.length - 1; i > 0 && numLogsProcessed < _n; i--) {
             int256 currentAPR = calculateAPRUsingLogs(i - 1, i);

--- a/contracts/abstract/ReaperBaseStrategyv2.sol
+++ b/contracts/abstract/ReaperBaseStrategyv2.sol
@@ -170,31 +170,12 @@ abstract contract ReaperBaseStrategyv2 is
 
     /**
      * @dev Traverses the harvest log backwards _n items,
-     *      and returns the average APR calculated across all the included
-     *      log entries. APR is multiplied by PERCENT_DIVISOR to retain precision.
-     */
-    function averageAPRAcrossLastNHarvests(int256 _n) public view returns (int256) {
-        require(harvestLog.length >= 2, "need at least 2 log entries");
-
-        int256 runningAPRSum;
-        int256 numLogsProcessed;
-
-        for (uint256 i = harvestLog.length - 1; i > 0 && numLogsProcessed < _n; i--) {
-            runningAPRSum += calculateAPRUsingLogs(i - 1, i);
-            numLogsProcessed++;
-        }
-
-        return runningAPRSum / numLogsProcessed;
-    }
-
-    /**
-     * @dev Traverses the harvest log backwards _n items,
      *      and returns the trimmed average APR calculated across the included log entries.
      *      Highest and lowest values are trimmed. If unable to trim due to insufficient 
      *      log entries, falls back to simple average. APR is multiplied by PERCENT_DIVISOR 
      *      to retain precision.
      */
-    function trimmedAverageAPRAcrossLastNHarvests(uint256 _n) external view returns (int256) {
+    function averageAPRAcrossLastNHarvests(uint256 _n) external view returns (int256) {
         require(harvestLog.length >= 2, "need at least 2 log entries");
 
         if (_n >= harvestLog.length) {

--- a/contracts/abstract/ReaperBaseStrategyv2.sol
+++ b/contracts/abstract/ReaperBaseStrategyv2.sol
@@ -9,8 +9,6 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
-import "hardhat/console.sol"; //TODO: Remove
-
 abstract contract ReaperBaseStrategyv2 is
     IStrategy,
     UUPSUpgradeable,
@@ -152,7 +150,7 @@ abstract contract ReaperBaseStrategyv2 is
      *      override _harvestCore() and implement their specific logic in it.
      */
     function harvest() external override whenNotPaused {
-        // _harvestCore();
+        _harvestCore();
 
         uint256 vaultSharePrice = IVault(vault).getPricePerFullShare();
         if (block.timestamp >= harvestLog[harvestLog.length - 1].timestamp + harvestLogCadence 
@@ -187,16 +185,13 @@ abstract contract ReaperBaseStrategyv2 is
         int256[] memory positionalAPRs = new int256[](_n);
         int256 runningAPRSum;
         uint256 numLogsProcessed;
-        uint256 lowestAPRIndex = 0;
-        uint256 highestAPRIndex = 0;
+        uint256 lowestAPRIndex = _n - 1;
+        uint256 highestAPRIndex = lowestAPRIndex;
 
         for (uint256 i = harvestLog.length - 1; i > 0 && numLogsProcessed < _n; i--) {
             int256 currentAPR = calculateAPRUsingLogs(i - 1, i);
-            console.logInt(currentAPR);
             lowestAPRIndex = currentAPR < positionalAPRs[lowestAPRIndex] ? numLogsProcessed : lowestAPRIndex;
             highestAPRIndex = currentAPR > positionalAPRs[highestAPRIndex] ? numLogsProcessed : highestAPRIndex;
-            console.logUint(lowestAPRIndex);            
-            console.logUint(highestAPRIndex);
             positionalAPRs[numLogsProcessed++] = currentAPR;
             runningAPRSum += currentAPR;
         }

--- a/test/starter-test.js
+++ b/test/starter-test.js
@@ -342,7 +342,79 @@ describe('Vaults', function () {
       expect(hasCallFee).to.equal(true);
     });
 
-    describe.skip('BaseStrategy', function () {
+    describe.only('BaseStrategy', function () {
+      it('should smooth harvest logs positive up', async function () {
+        const timeToSkip = 600;
+        const initialUserBalance = await want.balanceOf(wantHolderAddr);
+        const depositAmount = initialUserBalance.div(10);
+        await vault.connect(wantHolder).deposit(depositAmount);
+        const initialVaultBalance = await vault.balance();
+        await strategy.updateHarvestLogCadence(timeToSkip / 2);
+        const numHarvests = 10;
+        for (let i = 0; i < numHarvests - 1; i++) {
+          const fudgeNum = depositAmount.mul(i + 1).div(10000).mul(-1);
+          console.log(fudgeNum);
+          await strategy.fudge(fudgeNum);
+          await moveTimeForward(timeToSkip);
+          await strategy.harvest();
+        }
+        const averageAPR = await strategy.averageAPRAcrossLastNHarvests(numHarvests);
+        console.log(`Trimmed average APR across ${numHarvests} harvests is ${averageAPR} basis points.`);
+      });
+      it('should smooth harvest logs positive down', async function () {
+        const timeToSkip = 600;
+        const initialUserBalance = await want.balanceOf(wantHolderAddr);
+        const depositAmount = initialUserBalance.div(10);
+        await vault.connect(wantHolder).deposit(depositAmount);
+        const initialVaultBalance = await vault.balance();
+        await strategy.updateHarvestLogCadence(timeToSkip / 2);
+        const numHarvests = 10;
+        for (let i = 0; i < numHarvests - 1; i++) {
+          const fudgeNum = depositAmount.mul(11 - i).div(10000);
+          console.log(fudgeNum);
+          await strategy.fudge(fudgeNum);
+          await moveTimeForward(timeToSkip);
+          await strategy.harvest();
+        }
+        const averageAPR = await strategy.averageAPRAcrossLastNHarvests(numHarvests);
+        console.log(`Trimmed average APR across ${numHarvests} harvests is ${averageAPR} basis points.`);
+      });
+      it('should smooth harvest logs negative down', async function () {
+        const timeToSkip = 600;
+        const initialUserBalance = await want.balanceOf(wantHolderAddr);
+        const depositAmount = initialUserBalance.div(10);
+        await vault.connect(wantHolder).deposit(depositAmount);
+        const initialVaultBalance = await vault.balance();
+        await strategy.updateHarvestLogCadence(timeToSkip / 2);
+        const numHarvests = 10;
+        for (let i = 0; i < numHarvests - 1; i++) {
+          const fudgeNum = depositAmount.mul(i + 1).div(10000).mul(-1);
+          console.log(fudgeNum);
+          await strategy.fudge(fudgeNum);
+          await moveTimeForward(timeToSkip);
+          await strategy.harvest();
+        }
+        const averageAPR = await strategy.averageAPRAcrossLastNHarvests(numHarvests);
+        console.log(`Trimmed average APR across ${numHarvests} harvests is ${averageAPR} basis points.`);
+      });
+      it('should smooth harvest logs negative up', async function () {
+        const timeToSkip = 600;
+        const initialUserBalance = await want.balanceOf(wantHolderAddr);
+        const depositAmount = initialUserBalance.div(10);
+        await vault.connect(wantHolder).deposit(depositAmount);
+        const initialVaultBalance = await vault.balance();
+        await strategy.updateHarvestLogCadence(timeToSkip / 2);
+        const numHarvests = 10;
+        for (let i = 0; i < numHarvests - 1; i++) {
+          const fudgeNum = depositAmount.mul(11 - i).div(10000).mul(-1);
+          console.log(fudgeNum);
+          await strategy.fudge(fudgeNum);
+          await moveTimeForward(timeToSkip);
+          await strategy.harvest();
+        }
+        const averageAPR = await strategy.averageAPRAcrossLastNHarvests(numHarvests);
+        console.log(`Trimmed average APR across ${numHarvests} harvests is ${averageAPR} basis points.`);
+      });
       it('averageAPR should revert if not enough log entries', async function () {
         const timeToSkip = 600;
         const initialUserBalance = await want.balanceOf(wantHolderAddr);
@@ -352,7 +424,7 @@ describe('Vaults', function () {
         await expect(strategy.averageAPRAcrossLastNHarvests(2)).to.be.revertedWith('need at least 2 log entries');
       });
 
-      it('averageAPR should handle N values larger than number of logs', async function () {
+      it.skip('averageAPR should handle N values larger than number of logs', async function () {
         const timeToSkip = 600;
         const initialUserBalance = await want.balanceOf(wantHolderAddr);
         const depositAmount = initialUserBalance.div(10);

--- a/test/starter-test.js
+++ b/test/starter-test.js
@@ -342,79 +342,7 @@ describe('Vaults', function () {
       expect(hasCallFee).to.equal(true);
     });
 
-    describe.only('BaseStrategy', function () {
-      it('should smooth harvest logs positive up', async function () {
-        const timeToSkip = 600;
-        const initialUserBalance = await want.balanceOf(wantHolderAddr);
-        const depositAmount = initialUserBalance.div(10);
-        await vault.connect(wantHolder).deposit(depositAmount);
-        const initialVaultBalance = await vault.balance();
-        await strategy.updateHarvestLogCadence(timeToSkip / 2);
-        const numHarvests = 10;
-        for (let i = 0; i < numHarvests - 1; i++) {
-          const fudgeNum = depositAmount.mul(i + 1).div(10000).mul(-1);
-          console.log(fudgeNum);
-          await strategy.fudge(fudgeNum);
-          await moveTimeForward(timeToSkip);
-          await strategy.harvest();
-        }
-        const averageAPR = await strategy.averageAPRAcrossLastNHarvests(numHarvests);
-        console.log(`Trimmed average APR across ${numHarvests} harvests is ${averageAPR} basis points.`);
-      });
-      it('should smooth harvest logs positive down', async function () {
-        const timeToSkip = 600;
-        const initialUserBalance = await want.balanceOf(wantHolderAddr);
-        const depositAmount = initialUserBalance.div(10);
-        await vault.connect(wantHolder).deposit(depositAmount);
-        const initialVaultBalance = await vault.balance();
-        await strategy.updateHarvestLogCadence(timeToSkip / 2);
-        const numHarvests = 10;
-        for (let i = 0; i < numHarvests - 1; i++) {
-          const fudgeNum = depositAmount.mul(11 - i).div(10000);
-          console.log(fudgeNum);
-          await strategy.fudge(fudgeNum);
-          await moveTimeForward(timeToSkip);
-          await strategy.harvest();
-        }
-        const averageAPR = await strategy.averageAPRAcrossLastNHarvests(numHarvests);
-        console.log(`Trimmed average APR across ${numHarvests} harvests is ${averageAPR} basis points.`);
-      });
-      it('should smooth harvest logs negative down', async function () {
-        const timeToSkip = 600;
-        const initialUserBalance = await want.balanceOf(wantHolderAddr);
-        const depositAmount = initialUserBalance.div(10);
-        await vault.connect(wantHolder).deposit(depositAmount);
-        const initialVaultBalance = await vault.balance();
-        await strategy.updateHarvestLogCadence(timeToSkip / 2);
-        const numHarvests = 10;
-        for (let i = 0; i < numHarvests - 1; i++) {
-          const fudgeNum = depositAmount.mul(i + 1).div(10000).mul(-1);
-          console.log(fudgeNum);
-          await strategy.fudge(fudgeNum);
-          await moveTimeForward(timeToSkip);
-          await strategy.harvest();
-        }
-        const averageAPR = await strategy.averageAPRAcrossLastNHarvests(numHarvests);
-        console.log(`Trimmed average APR across ${numHarvests} harvests is ${averageAPR} basis points.`);
-      });
-      it('should smooth harvest logs negative up', async function () {
-        const timeToSkip = 600;
-        const initialUserBalance = await want.balanceOf(wantHolderAddr);
-        const depositAmount = initialUserBalance.div(10);
-        await vault.connect(wantHolder).deposit(depositAmount);
-        const initialVaultBalance = await vault.balance();
-        await strategy.updateHarvestLogCadence(timeToSkip / 2);
-        const numHarvests = 10;
-        for (let i = 0; i < numHarvests - 1; i++) {
-          const fudgeNum = depositAmount.mul(11 - i).div(10000).mul(-1);
-          console.log(fudgeNum);
-          await strategy.fudge(fudgeNum);
-          await moveTimeForward(timeToSkip);
-          await strategy.harvest();
-        }
-        const averageAPR = await strategy.averageAPRAcrossLastNHarvests(numHarvests);
-        console.log(`Trimmed average APR across ${numHarvests} harvests is ${averageAPR} basis points.`);
-      });
+    describe.skip('BaseStrategy', function () {
       it('averageAPR should revert if not enough log entries', async function () {
         const timeToSkip = 600;
         const initialUserBalance = await want.balanceOf(wantHolderAddr);
@@ -424,7 +352,7 @@ describe('Vaults', function () {
         await expect(strategy.averageAPRAcrossLastNHarvests(2)).to.be.revertedWith('need at least 2 log entries');
       });
 
-      it.skip('averageAPR should handle N values larger than number of logs', async function () {
+      it('averageAPR should handle N values larger than number of logs', async function () {
         const timeToSkip = 600;
         const initialUserBalance = await want.balanceOf(wantHolderAddr);
         const depositAmount = initialUserBalance.div(10);

--- a/test/starter-test.js
+++ b/test/starter-test.js
@@ -388,8 +388,11 @@ describe('Vaults', function () {
         await want.connect(wantHolder).transfer(strategy.address, ethers.utils.parseEther('1'));
         await moveTimeForward(timeToSkip); // Unexpected large harvest
         await strategy.harvest();
-        const legacyAverageAPR = await strategy.averageAPRAcrossLastNHarvests(2);
-        const averageAPR = await strategy.trimmedAverageAPRAcrossLastNHarvests(2);
+        let legacyAverageAPR = await strategy.averageAPRAcrossLastNHarvests(2);
+        let averageAPR = await strategy.trimmedAverageAPRAcrossLastNHarvests(2);
+        expect(averageAPR).to.be.equal(legacyAverageAPR);
+        legacyAverageAPR = await strategy.averageAPRAcrossLastNHarvests(1);
+        averageAPR = await strategy.trimmedAverageAPRAcrossLastNHarvests(1);
         expect(averageAPR).to.be.equal(legacyAverageAPR);
       });
       it('should revert if not enough log entries', async function () {
@@ -398,7 +401,7 @@ describe('Vaults', function () {
         const depositAmount = initialUserBalance.div(10);
         await vault.connect(wantHolder).deposit(depositAmount);
         await strategy.updateHarvestLogCadence(timeToSkip / 2);
-        await expect(strategy.trimmedAverageAPRAcrossLastNHarvests(1)).to.be.revertedWith('need at least 2 log entries');
+        await expect(strategy.trimmedAverageAPRAcrossLastNHarvests(2)).to.be.revertedWith('need at least 2 log entries');
       });
     });
   });


### PR DESCRIPTION
Under certain real-world conditions, the *averageAPRAcrossLastNHarvests(_n)* function called by the web app reflects spikes in the APR that have sometimes caused confusion with vault users.  Data shown in the app is averaged over _n = 2 (2 periods).  This PR aims to provide an additional option for app developers to increase the number of periods to 4 or more, and smooth the data returned by this function.  Meanwhile, the behavior for the existing _n = 2 case remains unchanged.  More details of the analysis and trimmed mean algorithm selected [are available](https://docs.google.com/spreadsheets/d/1Ui-4eudKmRE1gnocZETIRGsb97Ufvqj8V42RhugJ190/edit?usp=sharing).

* Modify `ReaperBaseStrategyv2.sol` *harvest()* function to only create log entries if vaultSharePrice has changed since last entry.  While this significantly improves the data smoothing, it does introduce a potentially misleading case where harvest returns drop to zero, but no further log entries are generated as long as it remains zero.  The average APR function will continue to show a non-zero value.  Strategies under these conditions should probably by paused or discontinued, in any case.
* Modify `ReaperBaseStrategyv2.sol` *averageAPRAcrossLastNHarvests(uint256 _n)* function to use a trimmed mean method when _n is large enough (_n >= 4). This smooths out high and low outlier values in the average calculation.  When _n < 4, results are unchanged from previous implementation; Function falls back to simple average.
* Add verification assertion in `starter-test.js` 'should be able to harvest' to manually calculate simple average alongside trimmed mean and ensure that they match within 5%. This is expected for constant harvests in testing, and is validating the new trimmed mean calculation method is in line with previous for this nominal case.  **Note:** If this test is used for a strategy that returns varied harvest amounts under test conditions (constant time interval), this assertion may fail.
* More extensive regression testing on the updated *averageAPRAcrossLastNHarvests()* function was done under commit cartman-dev/tomb-farmer@26c089fd3270148fc3036e377bdeb154e3d13bea to validate that the updated function works as described, and falls back to the previous behavior when expected.
* Some passing unit tests are retained in `starter-test.js` test suite `BaseStrategy` but are skipped, since BaseStrategy is not usually modified in this repo workflow.  If making changes to the `BaseStrategy`, these tests can be enabled.